### PR TITLE
Remove not existing relics

### DIFF
--- a/relics.json
+++ b/relics.json
@@ -787,11 +787,6 @@
       "id": 148
     },
     {
-      "name": "Natural Hierarchy",
-      "icon": "https://web.poecdn.com/image/Art/2DItems/Amulets/TalismanUnique2.png?scale=1&scaleIndex=0&w=1&h=1",
-      "id": 149
-    },
-    {
       "name": "Eyes of the Greatwolf",
       "icon": "https://web.poecdn.com/image/Art/2DItems/Amulets/RigwaldsTalisman.png?scale=1&scaleIndex=0&w=1&h=1",
       "id": 150

--- a/relics.json
+++ b/relics.json
@@ -772,11 +772,6 @@
       "id": 145
     },
     {
-      "name": "Night's Hold",
-      "icon": "https://web.poecdn.com/image/Art/2DItems/Amulets/SocketedTalisman.png?scale=1&scaleIndex=0&w=1&h=1",
-      "id": 146
-    },
-    {
       "name": "Blightwell",
       "icon": "https://web.poecdn.com/image/Art/2DItems/Amulets/TaintedSprings.png?scale=1&scaleIndex=0&w=1&h=1",
       "id": 147


### PR DESCRIPTION
`Natural Hierarchy` and `Night's Hold` don't exist ingame AFAIU.

Proof:
- https://www.pathofexile.com/trade/search/Delve/Kra66gi5
- https://www.pathofexile.com/trade/search/Delve/yKlWtR

It's a similar case for `Skin of the Lords` however Breach relics can be upgraded and still remain relics (_pssst! making money_). So I wonder if talismans can be produced somehow? No mention on Wiki though. @Kexort any ideas? If not let's remove these. Leaves us with 150 total.