### PR TITLE
Remove vertical scroll

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -3,6 +3,7 @@ body {
   height: 100%;
   color: #fff;
   background-repeat: repeat-y;
+  overflow-x:hidden;
 }
 
 .checklist {


### PR DESCRIPTION
There's a small vertical scroll on windows OS, this removes it. Might be caused by body width 100%. There might be a better solution.